### PR TITLE
Fix shell injection risk in release workflows

### DIFF
--- a/.github/workflows/cc-marketplace-release.yml
+++ b/.github/workflows/cc-marketplace-release.yml
@@ -18,9 +18,21 @@ jobs:
         with:
           ref: main
 
+      - name: Validate release version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          version="$RAW_VERSION"
+          semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+          printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
       - name: Update versions and generate marketplace.json
         run: |
-          VERSION=${{ inputs.version }}
+          VERSION="$RELEASE_VERSION"
 
           # Update version in each plugin.json
           for f in */.claude-plugin/plugin.json; do
@@ -39,6 +51,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes"
           else
-            git commit -m "chore: update plugin versions to ${{ inputs.version }}"
+            git commit -m "chore: update plugin versions to ${RELEASE_VERSION}"
             git push
           fi

--- a/.github/workflows/claude-irc-release.yml
+++ b/.github/workflows/claude-irc-release.yml
@@ -16,6 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate release version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          version="$RAW_VERSION"
+          semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+          printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -25,7 +37,7 @@ jobs:
       - name: Build binaries
         run: |
           cd claude-irc
-          VERSION=${{ inputs.version }}
+          VERSION="$RELEASE_VERSION"
           LDFLAGS="-s -w -X main.version=${VERSION}"
           mkdir -p dist
           GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/claude-irc-darwin-arm64 ./cmd/claude-irc
@@ -36,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.version }}" \
+          gh release upload "$RELEASE_VERSION" \
             claude-irc/dist/claude-irc-darwin-arm64 \
             claude-irc/dist/claude-irc-darwin-amd64 \
             claude-irc/dist/claude-irc-linux-amd64

--- a/.github/workflows/redit-release.yml
+++ b/.github/workflows/redit-release.yml
@@ -16,6 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate release version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          version="$RAW_VERSION"
+          semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+          printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -26,7 +38,7 @@ jobs:
         run: |
           cd redit
           mkdir -p dist
-          LDFLAGS="-s -w -X main.version=${{ inputs.version }}"
+          LDFLAGS="-s -w -X main.version=${RELEASE_VERSION}"
           GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/redit-darwin-arm64 ./cmd/redit
           GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/redit-darwin-amd64 ./cmd/redit
           GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/redit-linux-amd64 ./cmd/redit
@@ -36,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.version }}" \
+          gh release upload "$RELEASE_VERSION" \
             redit/dist/redit-darwin-arm64 \
             redit/dist/redit-darwin-amd64 \
             redit/dist/redit-linux-amd64 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate release tag
+        env:
+          RAW_TAG: ${{ github.ref_name }}
+        run: |
+          tag="$RAW_TAG"
+          semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if ! printf '%s\n' "$tag" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release tag: $tag" >&2
+            exit 1
+          fi
+          printf 'RELEASE_TAG=%s\n' "$tag" >> "$GITHUB_ENV"
+
       - name: Generate Release Notes
         id: notes
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          TAG="$RELEASE_TAG"
           PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | sed -n '2p')
 
           BODY=""
@@ -38,7 +50,7 @@ jobs:
             else
               while IFS= read -r line; do
                 # Strip commit hash prefix
-                MSG=$(echo "$line" | sed 's/^[a-f0-9]* //')
+                MSG="${line#* }"
                 BODY="${BODY}- ${MSG}"$'\n'
               done <<< "$COMMITS"
             fi
@@ -52,8 +64,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
+          gh release create "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" \
             --notes-file /tmp/release-notes.md
 
   claude-irc:

--- a/.github/workflows/vaultkey-release.yml
+++ b/.github/workflows/vaultkey-release.yml
@@ -16,6 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate release version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          version="$RAW_VERSION"
+          semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+          printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -26,7 +38,7 @@ jobs:
         run: |
           cd vaultkey
           mkdir -p dist
-          LDFLAGS="-s -w -X main.version=${{ inputs.version }}"
+          LDFLAGS="-s -w -X main.version=${RELEASE_VERSION}"
           GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o dist/vaultkey-darwin-arm64 ./cmd/vaultkey
           GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/vaultkey-darwin-amd64 ./cmd/vaultkey
           GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o dist/vaultkey-linux-amd64 ./cmd/vaultkey
@@ -36,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.version }}" \
+          gh release upload "$RELEASE_VERSION" \
             vaultkey/dist/vaultkey-darwin-arm64 \
             vaultkey/dist/vaultkey-darwin-amd64 \
             vaultkey/dist/vaultkey-linux-amd64 \

--- a/.github/workflows/webform-release.yml
+++ b/.github/workflows/webform-release.yml
@@ -16,6 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate release version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          version="$RAW_VERSION"
+          semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+          printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -25,7 +37,7 @@ jobs:
       - name: Build binaries
         run: |
           cd webform
-          VERSION=${{ inputs.version }}
+          VERSION="$RELEASE_VERSION"
           LDFLAGS="-s -w -X main.version=${VERSION}"
           mkdir -p dist
           GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/webform-darwin-arm64 ./cmd/webform
@@ -36,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.version }}" \
+          gh release upload "$RELEASE_VERSION" \
             webform/dist/webform-darwin-arm64 \
             webform/dist/webform-darwin-amd64 \
             webform/dist/webform-linux-amd64

--- a/.github/workflows/whip-release.yml
+++ b/.github/workflows/whip-release.yml
@@ -16,6 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate release version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          version="$RAW_VERSION"
+          semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+          printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -25,7 +37,7 @@ jobs:
       - name: Build binaries
         run: |
           cd whip
-          VERSION=${{ inputs.version }}
+          VERSION="$RELEASE_VERSION"
           LDFLAGS="-s -w -X main.version=${VERSION}"
           mkdir -p dist
           GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/whip-darwin-arm64 ./cmd/whip
@@ -36,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.version }}" \
+          gh release upload "$RELEASE_VERSION" \
             whip/dist/whip-darwin-arm64 \
             whip/dist/whip-darwin-amd64 \
             whip/dist/whip-linux-amd64


### PR DESCRIPTION
## Summary
- validate release tag/version inputs through env-backed semver checks before any shell use
- replace shell-time `${{ github.ref_name }}` / `${{ inputs.version }}` interpolation with validated env variables
- cover all reusable release workflows plus marketplace sync and top-level release creation flow

## Validation
- `actionlint .github/workflows/*.yml`
- `git diff --check`

## Notes
- Expands issue scope to also cover `redit` and `vaultkey` release workflows, which were affected by the same pattern.

Refs #6
