### PR TITLE
Validate claude-irc HTTP-controlled identifiers before filesystem access

### DIFF
--- a/claude-irc/cmd/claude-irc/main.go
+++ b/claude-irc/cmd/claude-irc/main.go
@@ -70,7 +70,7 @@ func joinCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			if !isValidPeerName(name) {
+			if !irc.IsValidPeerName(name) {
 				return fmt.Errorf("invalid peer name '%s': only letters, numbers, hyphens, and underscores allowed (max 32 chars)", name)
 			}
 
@@ -161,7 +161,7 @@ func msgCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			peer, content := args[0], args[1]
 
-			if !isValidPeerName(peer) {
+			if !irc.IsValidPeerName(peer) {
 				return fmt.Errorf("invalid peer name '%s'", peer)
 			}
 			if strings.TrimSpace(content) == "" {
@@ -392,19 +392,6 @@ func resolveMyName(store *irc.Store) (string, error) {
 	}
 
 	return "", fmt.Errorf("not joined (run 'claude-irc join <name>' first, or use --name)")
-}
-
-// isValidPeerName checks that a peer name contains only safe characters.
-func isValidPeerName(name string) bool {
-	if name == "" || len(name) > 32 {
-		return false
-	}
-	for _, c := range name {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
-			return false
-		}
-	}
-	return true
 }
 
 func serveCmd() *cobra.Command {

--- a/claude-irc/internal/irc/identifiers.go
+++ b/claude-irc/internal/irc/identifiers.go
@@ -1,0 +1,46 @@
+package irc
+
+import (
+	"errors"
+	"fmt"
+)
+
+const maxSafeIdentifierLength = 32
+
+var ErrInvalidIdentifier = errors.New("invalid identifier")
+
+// IsValidPeerName reports whether a peer name is safe to use in filesystem-backed paths.
+func IsValidPeerName(name string) bool {
+	return isValidSafeIdentifier(name)
+}
+
+func validatePeerName(name string) error {
+	return validateSafeIdentifier("peer name", name)
+}
+
+func validateTaskID(id string) error {
+	return validateSafeIdentifier("task id", id)
+}
+
+func validateSafeIdentifier(kind, value string) error {
+	if !isValidSafeIdentifier(value) {
+		return fmt.Errorf("%w: invalid %s", ErrInvalidIdentifier, kind)
+	}
+	return nil
+}
+
+func isValidSafeIdentifier(value string) bool {
+	if value == "" || len(value) > maxSafeIdentifierLength {
+		return false
+	}
+	for _, c := range value {
+		if !((c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' ||
+			c == '_') {
+			return false
+		}
+	}
+	return true
+}

--- a/claude-irc/internal/irc/messages.go
+++ b/claude-irc/internal/irc/messages.go
@@ -20,6 +20,10 @@ type Message struct {
 
 // SendMessage writes a message to a peer's inbox directory.
 func (s *Store) SendMessage(to, from, content string) error {
+	if err := validatePeerName(to); err != nil {
+		return err
+	}
+
 	dir := s.InboxDir(to)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create inbox dir: %w", err)
@@ -44,6 +48,10 @@ func (s *Store) SendMessage(to, from, content string) error {
 
 // ReadInbox returns all messages for a peer, sorted chronologically.
 func (s *Store) ReadInbox(name string) ([]Message, error) {
+	if err := validatePeerName(name); err != nil {
+		return nil, err
+	}
+
 	dir := s.InboxDir(name)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -106,12 +114,20 @@ func (s *Store) UnreadCount(name string) (int, error) {
 
 // ClearInbox removes all messages from a peer's inbox.
 func (s *Store) ClearInbox(name string) error {
+	if err := validatePeerName(name); err != nil {
+		return err
+	}
+
 	dir := s.InboxDir(name)
 	return os.RemoveAll(dir)
 }
 
 // MarkAllRead marks all messages in a peer's inbox as read.
 func (s *Store) MarkAllRead(name string) error {
+	if err := validatePeerName(name); err != nil {
+		return err
+	}
+
 	dir := s.InboxDir(name)
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/claude-irc/internal/irc/server.go
+++ b/claude-irc/internal/irc/server.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -384,6 +385,10 @@ func handlePostMessage(w http.ResponseWriter, r *http.Request, store *Store) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "to, from, and content are required"})
 		return
 	}
+	if err := validatePeerName(body.To); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 	if body.From != dashboardOperatorName {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "only 'user' may send messages over HTTP"})
 		return
@@ -408,7 +413,7 @@ func handleGetMessages(w http.ResponseWriter, r *http.Request, store *Store, nam
 	}
 
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, statusForIdentifierError(err), map[string]string{"error": err.Error()})
 		return
 	}
 	if messages == nil {
@@ -419,7 +424,7 @@ func handleGetMessages(w http.ResponseWriter, r *http.Request, store *Store, nam
 
 func handleMarkRead(w http.ResponseWriter, store *Store, name string) {
 	if err := store.MarkAllRead(name); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, statusForIdentifierError(err), map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
@@ -427,10 +432,17 @@ func handleMarkRead(w http.ResponseWriter, store *Store, name string) {
 
 func handleDeleteMessages(w http.ResponseWriter, store *Store, name string) {
 	if err := store.ClearInbox(name); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, statusForIdentifierError(err), map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func statusForIdentifierError(err error) int {
+	if errors.Is(err, ErrInvalidIdentifier) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
 }
 
 // Whip task types (minimal, no whip package import)
@@ -513,6 +525,10 @@ func readAllWhipTasks() ([]whipTask, error) {
 }
 
 func readWhipTask(id string) (*whipTask, error) {
+	if err := validateTaskID(id); err != nil {
+		return nil, err
+	}
+
 	dir := whipTasksDir()
 	if dir == "" {
 		return nil, fmt.Errorf("cannot determine home directory")
@@ -558,7 +574,14 @@ func handleGetTasks(w http.ResponseWriter) {
 func handleGetTask(w http.ResponseWriter, id string) {
 	task, err := readWhipTask(id)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		status := http.StatusInternalServerError
+		switch {
+		case errors.Is(err, ErrInvalidIdentifier):
+			status = http.StatusBadRequest
+		case os.IsNotExist(err), strings.Contains(err.Error(), "not found"):
+			status = http.StatusNotFound
+		}
+		writeJSON(w, status, map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, task)

--- a/claude-irc/internal/irc/server_test.go
+++ b/claude-irc/internal/irc/server_test.go
@@ -473,6 +473,62 @@ func TestAPIUserInboxFlow(t *testing.T) {
 	}
 }
 
+func TestAPIMessageRoutesRejectInvalidIdentifiers(t *testing.T) {
+	ts, store, token := setupTestServer(t)
+
+	sentinel := filepath.Join(store.BaseDir, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0644); err != nil {
+		t.Fatalf("failed to write sentinel: %v", err)
+	}
+
+	postBodies := []map[string]string{
+		{"to": "..", "from": "user", "content": "blocked traversal"},
+		{"to": "agent/1", "from": "user", "content": "blocked separator"},
+	}
+	for _, body := range postBodies {
+		resp := doRequest(t, ts, token, "POST", "/api/messages", body)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("POST /api/messages with %q: expected 400, got %d", body["to"], resp.StatusCode)
+		}
+		var result map[string]string
+		decodeJSON(t, resp, &result)
+		if result["error"] != "invalid identifier: invalid peer name" {
+			t.Fatalf("POST /api/messages with %q: unexpected error %q", body["to"], result["error"])
+		}
+	}
+
+	matches, err := filepath.Glob(filepath.Join(store.BaseDir, "*.json"))
+	if err != nil {
+		t.Fatalf("failed to glob base dir: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no root-level message files after invalid POSTs, got %v", matches)
+	}
+
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/api/messages/.."},
+		{method: http.MethodPost, path: "/api/messages/../read"},
+		{method: http.MethodDelete, path: "/api/messages/.."},
+	} {
+		resp := doRequest(t, ts, token, tc.method, tc.path, nil)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("%s %s: expected 400, got %d", tc.method, tc.path, resp.StatusCode)
+		}
+		var result map[string]string
+		decodeJSON(t, resp, &result)
+		if result["error"] != "invalid identifier: invalid peer name" {
+			t.Fatalf("%s %s: unexpected error %q", tc.method, tc.path, result["error"])
+		}
+	}
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected sentinel to survive invalid inbox paths: %v", err)
+	}
+}
+
 // --- Tasks ---
 
 func TestAPITasks(t *testing.T) {
@@ -578,6 +634,45 @@ func TestAPITaskPIDAlive(t *testing.T) {
 	decodeJSON(t, resp, &result)
 	if !result.PIDAlive {
 		t.Error("expected pid_alive=true for our own PID")
+	}
+}
+
+func TestAPITasksRejectInvalidID(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpHome := t.TempDir()
+	os.Setenv("HOME", tmpHome)
+	t.Cleanup(func() { os.Setenv("HOME", origHome) })
+
+	whipDir := filepath.Join(tmpHome, ".whip")
+	if err := os.MkdirAll(whipDir, 0755); err != nil {
+		t.Fatalf("failed to create whip dir: %v", err)
+	}
+
+	escapedTask := map[string]interface{}{
+		"id":         "escaped",
+		"title":      "Should not be reachable",
+		"status":     "in_progress",
+		"shell_pid":  0,
+		"depends_on": []string{},
+		"created_at": time.Now().Format(time.RFC3339Nano),
+		"updated_at": time.Now().Format(time.RFC3339Nano),
+	}
+	data, _ := json.MarshalIndent(escapedTask, "", "  ")
+	if err := os.WriteFile(filepath.Join(whipDir, "task.json"), data, 0644); err != nil {
+		t.Fatalf("failed to write escaped task: %v", err)
+	}
+
+	ts, _, token := setupTestServer(t)
+
+	resp := doRequest(t, ts, token, "GET", "/api/tasks/..", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	decodeJSON(t, resp, &body)
+	if body["error"] != "invalid identifier: invalid task id" {
+		t.Fatalf("unexpected error: %q", body["error"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- centralize filesystem-safe identifier validation in `internal/irc`
- apply the shared validation to HTTP inbox/task routes and POST message targets before any path joins
- reuse the same peer-name validation from the CLI and add regression tests for traversal/malformed identifiers

## Validation
- `go test ./...`
- `git diff --check`

## Notes
- The issue is only partially accurate. The real vulnerable surface includes `POST /api/messages` `body.to`, not just route params.
- This PR is stacked on #8 because it builds on the localhost-bind hardening.

Refs #3
