### PR TITLE
Limit claude-irc HTTP JSON request bodies

### DIFF
--- a/claude-irc/internal/irc/server.go
+++ b/claude-irc/internal/irc/server.go
@@ -44,6 +44,12 @@ const dashboardOperatorName = "user"
 const defaultServerBindHost = "127.0.0.1"
 const defaultServerAdvertiseHost = "localhost"
 
+const (
+	maxHTTPJSONBodyBytes      int64 = 1 << 20
+	maxHTTPMessageContentSize       = 10 << 10
+	maxHTTPMasterKeysSize           = 10 << 10
+)
+
 // RunServer starts the HTTP API server and blocks until the context is cancelled.
 func RunServer(ctx context.Context, cfg ServerConfig) error {
 	token := cfg.Token
@@ -376,8 +382,7 @@ func handlePostMessage(w http.ResponseWriter, r *http.Request, store *Store) {
 		From    string `json:"from"`
 		Content string `json:"content"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+	if !decodeLimitedJSONBody(w, r, &body, "invalid request body") {
 		return
 	}
 
@@ -391,6 +396,12 @@ func handlePostMessage(w http.ResponseWriter, r *http.Request, store *Store) {
 	}
 	if body.From != dashboardOperatorName {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "only 'user' may send messages over HTTP"})
+		return
+	}
+	if len(body.Content) > maxHTTPMessageContentSize {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("content too large (%d bytes, max %d bytes)", len(body.Content), maxHTTPMessageContentSize),
+		})
 		return
 	}
 
@@ -603,12 +614,17 @@ func handleMasterKeys(w http.ResponseWriter, r *http.Request, sessionName string
 	var body struct {
 		Keys string `json:"keys"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid body"})
+	if !decodeLimitedJSONBody(w, r, &body, "invalid body") {
 		return
 	}
 	if body.Keys == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "keys required"})
+		return
+	}
+	if len(body.Keys) > maxHTTPMasterKeysSize {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("keys too large (%d bytes, max %d bytes)", len(body.Keys), maxHTTPMasterKeysSize),
+		})
 		return
 	}
 	// Split into literal text and trailing Enter if present
@@ -665,4 +681,20 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(v)
+}
+
+func decodeLimitedJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}, invalidBodyMessage string) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxHTTPJSONBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+			return false
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": invalidBodyMessage})
+		return false
+	}
+
+	return true
 }

--- a/claude-irc/internal/irc/server_test.go
+++ b/claude-irc/internal/irc/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -24,6 +25,22 @@ func setupTestServer(t *testing.T) (*httptest.Server, *Store, string) {
 
 	token := "test-token-abc123"
 	handler := buildHandler(store, token, shortCodeFromToken(token), "")
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	return ts, store, token
+}
+
+func setupTestServerWithMaster(t *testing.T, masterTmux string) (*httptest.Server, *Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := NewStoreWithBaseDir(dir)
+	if err != nil {
+		t.Fatalf("NewStoreWithBaseDir: %v", err)
+	}
+
+	token := "test-token-abc123"
+	handler := buildHandler(store, token, shortCodeFromToken(token), masterTmux)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
 
@@ -377,6 +394,50 @@ func TestAPIPostMessageValidation(t *testing.T) {
 	}
 }
 
+func TestAPIPostMessageRejectsOversizedBody(t *testing.T) {
+	ts, _, token := setupTestServer(t)
+
+	resp := doRequest(t, ts, token, "POST", "/api/messages", map[string]string{
+		"to":      "agent-1",
+		"from":    "user",
+		"content": strings.Repeat("a", int(maxHTTPJSONBodyBytes)),
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	decodeJSON(t, resp, &body)
+	if body["error"] != "request body too large" {
+		t.Fatalf("unexpected error: %q", body["error"])
+	}
+}
+
+func TestAPIPostMessageRejectsOversizedContent(t *testing.T) {
+	ts, _, token := setupTestServer(t)
+
+	content := strings.Repeat("a", maxHTTPMessageContentSize+1)
+	resp := doRequest(t, ts, token, "POST", "/api/messages", map[string]string{
+		"to":      "agent-1",
+		"from":    "user",
+		"content": content,
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	decodeJSON(t, resp, &body)
+	want := "content too large (10241 bytes, max 10240 bytes)"
+	if body["error"] != want {
+		t.Fatalf("unexpected error: %q", body["error"])
+	}
+}
+
 func TestAPIPostMessageRejectsNonUserSender(t *testing.T) {
 	ts, store, token := setupTestServer(t)
 
@@ -672,6 +733,48 @@ func TestAPITasksRejectInvalidID(t *testing.T) {
 	var body map[string]string
 	decodeJSON(t, resp, &body)
 	if body["error"] != "invalid identifier: invalid task id" {
+		t.Fatalf("unexpected error: %q", body["error"])
+	}
+}
+
+// --- Master ---
+
+func TestAPIMasterKeysRejectsOversizedBody(t *testing.T) {
+	ts, _, token := setupTestServerWithMaster(t, "master-session")
+
+	resp := doRequest(t, ts, token, "POST", "/api/master/keys", map[string]string{
+		"keys": strings.Repeat("a", int(maxHTTPJSONBodyBytes)),
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	decodeJSON(t, resp, &body)
+	if body["error"] != "request body too large" {
+		t.Fatalf("unexpected error: %q", body["error"])
+	}
+}
+
+func TestAPIMasterKeysRejectsOversizedKeys(t *testing.T) {
+	ts, _, token := setupTestServerWithMaster(t, "master-session")
+
+	keys := strings.Repeat("a", maxHTTPMasterKeysSize+1)
+	resp := doRequest(t, ts, token, "POST", "/api/master/keys", map[string]string{
+		"keys": keys,
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	decodeJSON(t, resp, &body)
+	want := "keys too large (10241 bytes, max 10240 bytes)"
+	if body["error"] != want {
 		t.Fatalf("unexpected error: %q", body["error"])
 	}
 }


### PR DESCRIPTION
## Summary
- apply a shared 1MB HTTP JSON body limit before decoding claude-irc POST requests
- add semantic size caps for message content and master key payloads
- cover oversized body and oversized field cases in server tests

## Testing
- go test ./...

Closes #7