### PR TITLE
Harden claude-irc auth and connect URL handling

### DIFF
--- a/claude-irc/cmd/claude-irc/main.go
+++ b/claude-irc/cmd/claude-irc/main.go
@@ -440,19 +440,13 @@ func serveCmd() *cobra.Command {
 				MasterTmux: masterTmux,
 				Token:      token,
 				OnReady: func(info irc.ServerInfo) {
-					connectURL := info.LocalURL
-					if publicURL != "" {
-						connectURL = publicURL
-					}
-					fullURL := fmt.Sprintf("%s?token=%s", connectURL, info.Token)
-					shortURL := fmt.Sprintf("%s/s/%s", connectURL, info.ShortCode)
-					webURL := fmt.Sprintf("https://whip.bang9.dev#%s", fullURL)
+					connectURL, shortURL, webURL := serveURLs(info, publicURL)
 					fmt.Fprintf(os.Stderr, "claude-irc serve started.\n")
-					fmt.Fprintf(os.Stderr, "Connect URL: %s\n", fullURL)
+					fmt.Fprintf(os.Stderr, "Connect URL: %s\n", connectURL)
 					fmt.Fprintf(os.Stderr, "Short URL: %s\n", shortURL)
 					if keyboardShortcutsAvailable() {
 						fmt.Fprintf(os.Stderr, "\nShortcuts: [o] open in browser  [c] copy URL  [q] quit\n")
-						go serveKeyboardLoop(ctx, webURL, fullURL, cancel)
+						go serveKeyboardLoop(ctx, webURL, connectURL, cancel)
 					}
 				},
 			})
@@ -465,6 +459,17 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&masterTmux, "master-tmux", "", "Master tmux session name for capture/input endpoints")
 	cmd.Flags().StringVar(&token, "token", "", "Pre-set auth token (reuse across restarts); if empty, a new one is generated")
 	return cmd
+}
+
+func serveURLs(info irc.ServerInfo, publicURL string) (connectURL string, shortURL string, webURL string) {
+	baseURL := info.LocalURL
+	if publicURL != "" {
+		baseURL = publicURL
+	}
+	connectURL = irc.ConnectURL(baseURL, info.Token)
+	shortURL = fmt.Sprintf("%s/s/%s", strings.TrimRight(baseURL, "/"), info.ShortCode)
+	webURL = irc.DashboardURL(connectURL)
+	return connectURL, shortURL, webURL
 }
 
 type keyboardLoopDeps struct {

--- a/claude-irc/cmd/claude-irc/main_test.go
+++ b/claude-irc/cmd/claude-irc/main_test.go
@@ -315,3 +315,43 @@ func TestServeKeyboardLoopWithDeps_MakeRawError(t *testing.T) {
 		t.Fatalf("expected raw mode failure to be reported, got %q", stderr.String())
 	}
 }
+
+func TestServeURLs_LocalConnectURLUsesFragmentToken(t *testing.T) {
+	info := irc.ServerInfo{
+		Token:     "test-token",
+		ShortCode: "abc12345",
+		LocalURL:  "http://localhost:8585",
+	}
+
+	connectURL, shortURL, webURL := serveURLs(info, "")
+
+	if connectURL != "http://localhost:8585#token=test-token" {
+		t.Fatalf("unexpected connect URL: %q", connectURL)
+	}
+	if shortURL != "http://localhost:8585/s/abc12345" {
+		t.Fatalf("unexpected short URL: %q", shortURL)
+	}
+	if webURL != "https://whip.bang9.dev#http://localhost:8585#token=test-token" {
+		t.Fatalf("unexpected web URL: %q", webURL)
+	}
+}
+
+func TestServeURLs_PublicURLOverridesLocalURL(t *testing.T) {
+	info := irc.ServerInfo{
+		Token:     "test-token",
+		ShortCode: "abc12345",
+		LocalURL:  "http://localhost:8585",
+	}
+
+	connectURL, shortURL, webURL := serveURLs(info, "https://public.example")
+
+	if connectURL != "https://public.example#token=test-token" {
+		t.Fatalf("unexpected connect URL: %q", connectURL)
+	}
+	if shortURL != "https://public.example/s/abc12345" {
+		t.Fatalf("unexpected short URL: %q", shortURL)
+	}
+	if webURL != "https://whip.bang9.dev#https://public.example#token=test-token" {
+		t.Fatalf("unexpected web URL: %q", webURL)
+	}
+}

--- a/claude-irc/internal/irc/server.go
+++ b/claude-irc/internal/irc/server.go
@@ -43,12 +43,7 @@ type ServerInfo struct {
 const dashboardOperatorName = "user"
 const defaultServerBindHost = "127.0.0.1"
 const defaultServerAdvertiseHost = "localhost"
-
-const (
-	maxHTTPJSONBodyBytes      int64 = 1 << 20
-	maxHTTPMessageContentSize       = 10 << 10
-	maxHTTPMasterKeysSize           = 10 << 10
-)
+const dashboardWebBaseURL = "https://whip.bang9.dev"
 
 const (
 	maxHTTPJSONBodyBytes      int64 = 1 << 20
@@ -210,6 +205,20 @@ func shortCodeFromToken(token string) string {
 	return hex.EncodeToString(h[:4]) // 8 hex chars
 }
 
+func ConnectURL(baseURL, token string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Sprintf("%s#token=%s", strings.TrimRight(baseURL, "#"), token)
+	}
+	u.RawQuery = ""
+	u.Fragment = "token=" + token
+	return u.String()
+}
+
+func DashboardURL(connectURL string) string {
+	return dashboardWebBaseURL + "#" + connectURL
+}
+
 func generateToken() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
@@ -225,9 +234,8 @@ func buildHandler(store *Store, token string, shortCode string, masterTmux strin
 		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/s/") {
 			code := strings.TrimPrefix(r.URL.Path, "/s/")
 			if code == shortCode {
-				host := r.Host
-				connectURL := fmt.Sprintf("https://%s?token=%s", host, token)
-				webURL := fmt.Sprintf("https://whip.bang9.dev#%s", connectURL)
+				connectURL := ConnectURL(requestBaseURL(r), token)
+				webURL := DashboardURL(connectURL)
 				http.Redirect(w, r, webURL, http.StatusFound)
 			} else {
 				http.NotFound(w, r)
@@ -272,19 +280,45 @@ func isAllowedOrigin(origin string) bool {
 	return localhostPattern.MatchString(origin)
 }
 
-func checkAuth(r *http.Request, token string) bool {
-	// Check Authorization header
-	auth := r.Header.Get("Authorization")
-	if strings.HasPrefix(auth, "Bearer ") {
-		if strings.TrimPrefix(auth, "Bearer ") == token {
-			return true
-		}
+func requestBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
 	}
-	// Check query param
-	if r.URL.Query().Get("token") == token {
+	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
+		scheme = forwarded
+	}
+	return fmt.Sprintf("%s://%s", scheme, r.Host)
+}
+
+func checkAuth(r *http.Request, token string) bool {
+	auth := r.Header.Get("Authorization")
+	if auth != "" {
+		return strings.HasPrefix(auth, "Bearer ") && strings.TrimPrefix(auth, "Bearer ") == token
+	}
+	if !allowLegacyQueryTokenAuth(r) {
+		return false
+	}
+	return r.URL.Query().Get("token") == token
+}
+
+func allowLegacyQueryTokenAuth(r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		return false
+	}
+
+	path := strings.TrimRight(r.URL.Path, "/")
+	switch path {
+	case "/api/peers", "/api/tasks":
 		return true
 	}
-	return false
+
+	if !strings.HasPrefix(path, "/api/tasks/") {
+		return false
+	}
+
+	taskID := strings.TrimPrefix(path, "/api/tasks/")
+	return taskID != "" && !strings.Contains(taskID, "/")
 }
 
 func route(w http.ResponseWriter, r *http.Request, store *Store, masterTmux string) {

--- a/claude-irc/internal/irc/server_test.go
+++ b/claude-irc/internal/irc/server_test.go
@@ -176,12 +176,43 @@ func TestAPIAuthBearerToken(t *testing.T) {
 	}
 }
 
-func TestAPIAuthQueryParam(t *testing.T) {
+func TestAPIAuthQueryParamPeers(t *testing.T) {
 	ts, _, token := setupTestServer(t)
 	resp := doRequest(t, ts, "", "GET", "/api/peers?token="+token, nil)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestAPIAuthQueryParamTasks(t *testing.T) {
+	ts, _, token := setupTestServer(t)
+	resp := doRequest(t, ts, "", "GET", "/api/tasks?token="+token, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestAPIAuthQueryParamRejectsMessages(t *testing.T) {
+	ts, _, token := setupTestServer(t)
+	resp := doRequest(t, ts, "", "GET", "/api/messages/user?token="+token, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestAPIAuthQueryParamRejectsMutatingEndpoints(t *testing.T) {
+	ts, _, token := setupTestServer(t)
+	resp := doRequest(t, ts, "", "POST", "/api/messages?token="+token, map[string]string{
+		"from":    "user",
+		"to":      "alice",
+		"content": "hello",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
 	}
 }
 
@@ -758,6 +789,30 @@ func TestAPIMasterKeysRejectsOversizedBody(t *testing.T) {
 	}
 }
 
+func TestAPIMasterStatusRejectsQueryAuth(t *testing.T) {
+	ts, _, token := setupTestServerWithMaster(t, "master-session")
+
+	resp := doRequest(t, ts, "", "GET", "/api/master/status?token="+token, nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestAPIMasterKeysRejectsQueryAuth(t *testing.T) {
+	ts, _, token := setupTestServerWithMaster(t, "master-session")
+
+	resp := doRequest(t, ts, "", "POST", "/api/master/keys?token="+token, map[string]string{
+		"keys": "whoami",
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
 func TestAPIMasterKeysRejectsOversizedKeys(t *testing.T) {
 	ts, _, token := setupTestServerWithMaster(t, "master-session")
 
@@ -834,6 +889,36 @@ func TestAPIRunServer(t *testing.T) {
 	// Token should be 32 hex chars
 	if len(gotInfo.Token) != 32 {
 		t.Errorf("expected 32-char token, got %d chars", len(gotInfo.Token))
+	}
+}
+
+func TestAPIShortURLRedirectUsesFragmentConnectURL(t *testing.T) {
+	ts, _, token := setupTestServer(t)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/s/"+shortCodeFromToken(token), nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+
+	wantLocation := DashboardURL(ConnectURL(ts.URL, token))
+	if got := resp.Header.Get("Location"); got != wantLocation {
+		t.Fatalf("expected redirect to %q, got %q", wantLocation, got)
 	}
 }
 

--- a/whip/cmd/whip/main.go
+++ b/whip/cmd/whip/main.go
@@ -1080,10 +1080,8 @@ func remoteCmd() *cobra.Command {
 			fmt.Fprintln(os.Stderr, "  Shortcuts: [o] open in browser  [c] copy URL  [q] quit")
 
 			// Extract token from connect URL and save config
-			if u, parseErr := url.Parse(connectURL); parseErr == nil {
-				if t := u.Query().Get("token"); t != "" {
-					cfg.ServeToken = t
-				}
+			if t := connectURLToken(connectURL); t != "" {
+				cfg.ServeToken = t
 			}
 			configChanged := false
 			if tunnel != cfg.Tunnel {
@@ -1275,4 +1273,19 @@ func timeAgo(t time.Time) string {
 	default:
 		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
 	}
+}
+
+func connectURLToken(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	if t := u.Query().Get("token"); t != "" {
+		return t
+	}
+	fragment, err := url.ParseQuery(u.Fragment)
+	if err != nil {
+		return ""
+	}
+	return fragment.Get("token")
 }

--- a/whip/cmd/whip/main_test.go
+++ b/whip/cmd/whip/main_test.go
@@ -20,3 +20,23 @@ func TestHelloCmd(t *testing.T) {
 		t.Fatalf("stdout = %q, want %q", got, "hello world\n")
 	}
 }
+
+func TestConnectURLToken(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "fragment token", raw: "https://public.example#token=abc123", want: "abc123"},
+		{name: "legacy query token", raw: "https://public.example?token=abc123", want: "abc123"},
+		{name: "missing token", raw: "https://public.example", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := connectURLToken(tc.raw); got != tc.want {
+				t.Fatalf("connectURLToken(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/whip/dashboard-web/src/api/client.ts
+++ b/whip/dashboard-web/src/api/client.ts
@@ -135,15 +135,23 @@ export class WhipAPIClient {
   }
 }
 
+export function buildConnectURL(baseURL: string, token: string): string {
+  const normalizedBaseURL = baseURL.replace(/[?#].*$/, '')
+  return `${normalizedBaseURL}#token=${encodeURIComponent(token)}`
+}
+
 export function parseConnectURL(input: string): { baseURL: string; token: string } | null {
   try {
-    // Handle web dashboard URL with hash fragment (e.g. https://whip.bang9.dev#https://host?token=xxx)
+    // Handle either a direct connect URL or a dashboard URL whose hash carries one.
     const url = new URL(input)
-    const raw = url.hash ? url.hash.slice(1) : input
+    const rawHash = url.hash.slice(1)
+    const raw = rawHash.startsWith('http://') || rawHash.startsWith('https://') ? rawHash : input
     const connectURL = new URL(raw)
-    const token = connectURL.searchParams.get('token')
+    const hashToken = new URLSearchParams(connectURL.hash.startsWith('#') ? connectURL.hash.slice(1) : connectURL.hash).get('token')
+    const token = hashToken ?? connectURL.searchParams.get('token')
     if (!token) return null
     connectURL.search = ''
+    connectURL.hash = ''
     return { baseURL: connectURL.toString(), token }
   } catch {
     return null

--- a/whip/dashboard-web/src/pages/LoginPage.tsx
+++ b/whip/dashboard-web/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { WhipAPIClient, parseConnectURL, AuthError, ConnectionError } from '../api/client'
+import { WhipAPIClient, buildConnectURL, parseConnectURL, AuthError, ConnectionError } from '../api/client'
 import { saveAuth, clearAuth, getClient, loadAuth } from '../stores/auth'
 
 interface Props {
@@ -48,7 +48,7 @@ export function LoginPage({ onLogin }: Props) {
           // Server temporarily unreachable — don't clear potentially valid credentials
           const auth = loadAuth()
           if (auth) {
-            setUrl(`${auth.baseURL}?token=${auth.token}`)
+            setUrl(buildConnectURL(auth.baseURL, auth.token))
           }
           setError('Cannot connect to server')
         } else {
@@ -67,7 +67,7 @@ export function LoginPage({ onLogin }: Props) {
 
     const parsed = parseConnectURL(url.trim())
     if (!parsed) {
-      setError('Invalid URL format. Expected: https://...?token=...')
+      setError('Invalid URL format. Expected: https://...#token=... (legacy ?token=... also works)')
       return
     }
 
@@ -119,7 +119,7 @@ export function LoginPage({ onLogin }: Props) {
               type="text"
               value={url}
               onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://xxx.trycloudflare.com?token=abc123"
+              placeholder="https://xxx.trycloudflare.com#token=abc123"
               disabled={loading}
               className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 text-sm placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-[#8B5CF6] focus:border-transparent transition-colors disabled:opacity-60"
             />

--- a/whip/dashboard-web/tests/client.test.ts
+++ b/whip/dashboard-web/tests/client.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildConnectURL, parseConnectURL } from '../src/api/client.ts'
+
+test('buildConnectURL uses a fragment token', () => {
+  assert.equal(buildConnectURL('https://public.example', 'abc123'), 'https://public.example#token=abc123')
+})
+
+test('parseConnectURL accepts fragment-style connect URLs', () => {
+  assert.deepEqual(parseConnectURL('https://public.example#token=abc123'), {
+    baseURL: 'https://public.example/',
+    token: 'abc123',
+  })
+})
+
+test('parseConnectURL accepts dashboard URLs that carry a fragment-style connect URL', () => {
+  assert.deepEqual(parseConnectURL('https://whip.bang9.dev#https://public.example#token=abc123'), {
+    baseURL: 'https://public.example/',
+    token: 'abc123',
+  })
+})
+
+test('parseConnectURL keeps legacy query-token URLs working', () => {
+  assert.deepEqual(parseConnectURL('https://public.example?token=abc123'), {
+    baseURL: 'https://public.example/',
+    token: 'abc123',
+  })
+})

--- a/whip/internal/whip/dashboard.go
+++ b/whip/internal/whip/dashboard.go
@@ -67,10 +67,10 @@ const (
 	viewList viewState = iota
 	viewDetail
 	viewTmux
-	viewIRC           // peer selection list
-	viewIRCMsg        // message text input
-	viewRemoteConfig  // tunnel/port config input
-	viewRemoteStatus  // remote running status page
+	viewIRC          // peer selection list
+	viewIRCMsg       // message text input
+	viewRemoteConfig // tunnel/port config input
+	viewRemoteStatus // remote running status page
 )
 
 type ircSendResultMsg struct{ err error }
@@ -723,11 +723,9 @@ func (m DashboardModel) startRemote(cfg RemoteConfig) tea.Cmd {
 		}
 
 		// Save token from connect URL
-		if u, parseErr := url.Parse(result.ConnectURL); parseErr == nil {
-			if t := u.Query().Get("token"); t != "" {
-				storeCfg.ServeToken = t
-				m.store.SaveConfig(storeCfg)
-			}
+		if t := connectURLToken(result.ConnectURL); t != "" {
+			storeCfg.ServeToken = t
+			m.store.SaveConfig(storeCfg)
 		}
 
 		return remoteStartedMsg{cmd: cmd, url: result.ConnectURL, shortURL: result.ShortURL}
@@ -1717,6 +1715,21 @@ func timeAgo(t time.Time) string {
 	default:
 		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
 	}
+}
+
+func connectURLToken(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	if t := u.Query().Get("token"); t != "" {
+		return t
+	}
+	fragment, err := url.ParseQuery(u.Fragment)
+	if err != nil {
+		return ""
+	}
+	return fragment.Get("token")
 }
 
 func max(a, b int) int {


### PR DESCRIPTION
## Summary
- require Authorization header auth for claude-irc privileged and mutating endpoints while narrowing legacy query-token auth to low-risk GETs
- switch newly emitted connect URLs from `?token=` to fragment-style `#token=` links and keep dashboard parsing/login flows working
- preserve whip remote token persistence for the safer connect URL format and add focused server/CLI/parser tests

## Issue Scope Correction
Issue #5 is valid, but the correct fix is auth transport hardening rather than dangerous key-pattern filtering. `/api/master/keys` is already a privileged remote-control endpoint; the real risk reduction comes from preventing query-token leakage and requiring header auth on privileged/mutating routes.

## Testing
- cd claude-irc && go test ./...
- cd whip && go test ./...
- node --test /Users/airenkang/Desktop/side/ai-tools-worktrees/issue-5/whip/dashboard-web/tests/client.test.ts
- cd whip/dashboard-web && pnpm install --frozen-lockfile && pnpm build

Closes #5