### PR TITLE
Fix post-merge release regressions

### DIFF
--- a/.github/workflows/cc-marketplace-release.yml
+++ b/.github/workflows/cc-marketplace-release.yml
@@ -24,8 +24,14 @@ jobs:
         run: |
           version="$RAW_VERSION"
           semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
-            echo "Invalid release version: $version" >&2
+          case "$version" in
+            *$'\n'*|*$'\r'*)
+              echo "Invalid release version: must be a single-line semver tag" >&2
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: must match semver tag format" >&2
             exit 1
           fi
           printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"

--- a/.github/workflows/claude-irc-release.yml
+++ b/.github/workflows/claude-irc-release.yml
@@ -22,8 +22,14 @@ jobs:
         run: |
           version="$RAW_VERSION"
           semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
-            echo "Invalid release version: $version" >&2
+          case "$version" in
+            *$'\n'*|*$'\r'*)
+              echo "Invalid release version: must be a single-line semver tag" >&2
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: must match semver tag format" >&2
             exit 1
           fi
           printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"

--- a/.github/workflows/redit-release.yml
+++ b/.github/workflows/redit-release.yml
@@ -22,8 +22,14 @@ jobs:
         run: |
           version="$RAW_VERSION"
           semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
-            echo "Invalid release version: $version" >&2
+          case "$version" in
+            *$'\n'*|*$'\r'*)
+              echo "Invalid release version: must be a single-line semver tag" >&2
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: must match semver tag format" >&2
             exit 1
           fi
           printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"

--- a/.github/workflows/vaultkey-release.yml
+++ b/.github/workflows/vaultkey-release.yml
@@ -22,8 +22,14 @@ jobs:
         run: |
           version="$RAW_VERSION"
           semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
-            echo "Invalid release version: $version" >&2
+          case "$version" in
+            *$'\n'*|*$'\r'*)
+              echo "Invalid release version: must be a single-line semver tag" >&2
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: must match semver tag format" >&2
             exit 1
           fi
           printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"

--- a/.github/workflows/webform-release.yml
+++ b/.github/workflows/webform-release.yml
@@ -22,8 +22,14 @@ jobs:
         run: |
           version="$RAW_VERSION"
           semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
-            echo "Invalid release version: $version" >&2
+          case "$version" in
+            *$'\n'*|*$'\r'*)
+              echo "Invalid release version: must be a single-line semver tag" >&2
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: must match semver tag format" >&2
             exit 1
           fi
           printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"

--- a/.github/workflows/whip-release.yml
+++ b/.github/workflows/whip-release.yml
@@ -22,8 +22,14 @@ jobs:
         run: |
           version="$RAW_VERSION"
           semver_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if ! printf '%s\n' "$version" | grep -Eq "$semver_tag_pattern"; then
-            echo "Invalid release version: $version" >&2
+          case "$version" in
+            *$'\n'*|*$'\r'*)
+              echo "Invalid release version: must be a single-line semver tag" >&2
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$version" | grep -Eq "$semver_tag_pattern"; then
+            echo "Invalid release version: must match semver tag format" >&2
             exit 1
           fi
           printf 'RELEASE_VERSION=%s\n' "$version" >> "$GITHUB_ENV"

--- a/claude-irc/install.sh
+++ b/claude-irc/install.sh
@@ -62,6 +62,40 @@ download_file() {
     error "Neither curl nor wget is installed"
 }
 
+download_optional_file() {
+    local url="$1" dest="$2"
+    local http_code output
+
+    if command -v curl &> /dev/null; then
+        if ! http_code=$(curl -sSL -w '%{http_code}' -o "$dest" "$url"); then
+            rm -f "$dest"
+            return 1
+        fi
+        case "$http_code" in
+            200) return 0 ;;
+            404)
+                rm -f "$dest"
+                return 2
+                ;;
+        esac
+        rm -f "$dest"
+        return 1
+    fi
+
+    if command -v wget &> /dev/null; then
+        if output=$(wget -q -S -O "$dest" "$url" 2>&1); then
+            return 0
+        fi
+        rm -f "$dest"
+        if printf '%s\n' "$output" | grep -Eq 'HTTP/[0-9.]+\s+404'; then
+            return 2
+        fi
+        return 1
+    fi
+
+    error "Neither curl nor wget is installed"
+}
+
 sha256_file() {
     local file="$1"
     if command -v sha256sum &> /dev/null; then
@@ -93,21 +127,28 @@ lookup_checksum() {
     ' "$manifest"
 }
 
-install_verified_binary() {
+install_binary_with_optional_checksum() {
     local download_url="$1" checksum_url="$2" asset_name="$3" dest="$4"
     local tmp="${dest}.tmp.$$" manifest="${tmp}.checksums"
-    local expected_checksum actual_checksum
+    local expected_checksum actual_checksum checksum_status
 
-    if ! download_file "$checksum_url" "$manifest"; then
-        rm -f "$tmp" "$manifest"
-        return 1
-    fi
-
-    expected_checksum=$(lookup_checksum "$manifest" "$asset_name")
-    if [ -z "$expected_checksum" ]; then
-        warn "Checksum entry not found for ${asset_name}"
-        rm -f "$tmp" "$manifest"
-        return 1
+    if download_optional_file "$checksum_url" "$manifest"; then
+        expected_checksum=$(lookup_checksum "$manifest" "$asset_name")
+        if [ -z "$expected_checksum" ]; then
+            warn "Checksum entry not found for ${asset_name}"
+            rm -f "$tmp" "$manifest"
+            return 1
+        fi
+    else
+        checksum_status=$?
+        if [ "$checksum_status" -eq 2 ]; then
+            warn "Checksum manifest not found for ${asset_name}; installing without checksum verification"
+            rm -f "$manifest"
+            expected_checksum=""
+        else
+            rm -f "$tmp" "$manifest"
+            return 1
+        fi
     fi
 
     if ! download_file "$download_url" "$tmp"; then
@@ -115,15 +156,17 @@ install_verified_binary() {
         return 1
     fi
 
-    if ! actual_checksum=$(sha256_file "$tmp"); then
-        rm -f "$tmp" "$manifest"
-        return 1
-    fi
+    if [ -n "$expected_checksum" ]; then
+        if ! actual_checksum=$(sha256_file "$tmp"); then
+            rm -f "$tmp" "$manifest"
+            return 1
+        fi
 
-    if [ "$actual_checksum" != "$expected_checksum" ]; then
-        warn "Checksum mismatch for ${asset_name}"
-        rm -f "$tmp" "$manifest"
-        return 1
+        if [ "$actual_checksum" != "$expected_checksum" ]; then
+            warn "Checksum mismatch for ${asset_name}"
+            rm -f "$tmp" "$manifest"
+            return 1
+        fi
     fi
 
     if ! chmod +x "$tmp"; then
@@ -199,7 +242,7 @@ main() {
     mkdir -p "$INSTALL_DIR"
 
     info "Downloading ${binary_name}..."
-    if ! install_verified_binary "$download_url" "$checksums_url" "$binary_name" "${INSTALL_DIR}/${BINARY_NAME}"; then
+    if ! install_binary_with_optional_checksum "$download_url" "$checksums_url" "$binary_name" "${INSTALL_DIR}/${BINARY_NAME}"; then
         error "Download failed. Check if the release exists: https://github.com/${REPO}/releases/tag/${version}"
     fi
 

--- a/shared/upgrade/upgrade.go
+++ b/shared/upgrade/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,6 +37,16 @@ var (
 	}
 )
 
+type httpStatusError struct {
+	statusCode int
+	status     string
+	url        string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("unexpected status %s for %s", e.status, e.url)
+}
+
 // GetLatestVersion fetches the latest release tag from the GitHub API.
 func GetLatestVersion(repo string) (string, error) {
 	resp, err := httpClient.Get(latestReleaseURL(repo))
@@ -62,10 +73,10 @@ func GetLatestVersion(repo string) (string, error) {
 }
 
 // DownloadBinary downloads a release binary to destPath using the safe download
-// pattern: download to tmp file, verify its checksum, then move the new binary into place.
+// pattern: download to tmp file, verify its checksum when available, then move it into place.
 func DownloadBinary(repo, version, binaryName, destPath string) error {
 	platformBinary := platformBinaryName(binaryName)
-	expectedChecksum, err := fetchExpectedChecksum(repo, version, binaryName, platformBinary)
+	expectedChecksum, hasChecksum, err := fetchExpectedChecksum(repo, version, binaryName, platformBinary)
 	if err != nil {
 		return err
 	}
@@ -79,16 +90,25 @@ func DownloadBinary(repo, version, binaryName, destPath string) error {
 		return fmt.Errorf("download failed for %s: %w", binaryName, err)
 	}
 
-	actualChecksum, err := sha256File(tmpPath)
-	if err != nil {
-		return fmt.Errorf("checksum calculation failed for %s: %w", binaryName, err)
-	}
-	if !strings.EqualFold(actualChecksum, expectedChecksum) {
-		return fmt.Errorf(
-			"checksum mismatch for %s: expected %s, got %s",
+	if hasChecksum {
+		actualChecksum, err := sha256File(tmpPath)
+		if err != nil {
+			return fmt.Errorf("checksum calculation failed for %s: %w", binaryName, err)
+		}
+		if !strings.EqualFold(actualChecksum, expectedChecksum) {
+			return fmt.Errorf(
+				"checksum mismatch for %s: expected %s, got %s",
+				binaryName,
+				expectedChecksum,
+				actualChecksum,
+			)
+		}
+	} else {
+		fmt.Fprintf(
+			os.Stderr,
+			"Warning: checksum manifest missing for %s %s; installing without verification\n",
 			binaryName,
-			expectedChecksum,
-			actualChecksum,
+			version,
 		)
 	}
 
@@ -134,19 +154,22 @@ func checksumManifestName(binaryName string) string {
 	return binaryName + "-checksums.txt"
 }
 
-func fetchExpectedChecksum(repo, version, binaryName, assetName string) (string, error) {
+func fetchExpectedChecksum(repo, version, binaryName, assetName string) (string, bool, error) {
 	manifestURL := releaseAssetURL(repo, version, checksumManifestName(binaryName))
 	manifest, err := downloadBytes(manifestURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch checksum manifest for %s: %w", binaryName, err)
+		if isHTTPStatus(err, http.StatusNotFound) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to fetch checksum manifest for %s: %w", binaryName, err)
 	}
 
 	checksum, err := checksumForAsset(manifest, assetName)
 	if err != nil {
-		return "", fmt.Errorf("failed to read checksum for %s: %w", assetName, err)
+		return "", true, fmt.Errorf("failed to read checksum for %s: %w", assetName, err)
 	}
 
-	return checksum, nil
+	return checksum, true, nil
 }
 
 func checksumForAsset(manifest []byte, assetName string) (string, error) {
@@ -177,7 +200,11 @@ func downloadBytes(url string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status %s", resp.Status)
+		return nil, &httpStatusError{
+			statusCode: resp.StatusCode,
+			status:     resp.Status,
+			url:        url,
+		}
 	}
 
 	return io.ReadAll(resp.Body)
@@ -191,7 +218,11 @@ func downloadToFile(url, destPath string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %s", resp.Status)
+		return &httpStatusError{
+			statusCode: resp.StatusCode,
+			status:     resp.Status,
+			url:        url,
+		}
 	}
 
 	file, err := os.Create(destPath)
@@ -205,6 +236,11 @@ func downloadToFile(url, destPath string) error {
 	}
 
 	return file.Close()
+}
+
+func isHTTPStatus(err error, statusCode int) bool {
+	var statusErr *httpStatusError
+	return errors.As(err, &statusErr) && statusErr.statusCode == statusCode
 }
 
 func sha256File(path string) (string, error) {

--- a/shared/upgrade/upgrade_test.go
+++ b/shared/upgrade/upgrade_test.go
@@ -134,6 +134,45 @@ func TestDownloadBinaryVerifiedInstall(t *testing.T) {
 	}
 }
 
+func TestDownloadBinaryWithoutChecksumManifestFallsBackToUnverifiedInstall(t *testing.T) {
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "test-tool")
+	oldContent := []byte("old-binary-content")
+	if err := os.WriteFile(destPath, oldContent, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	binaryContent := []byte("legacy-release-binary")
+	assetName := platformBinaryName("test-tool")
+
+	withTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/test/repo/v1.2.3/test-tool-checksums.txt":
+			http.NotFound(w, r)
+		case "/releases/test/repo/v1.2.3/" + assetName:
+			w.Write(binaryContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	if err := DownloadBinary("test/repo", "v1.2.3", "test-tool", destPath); err != nil {
+		t.Fatalf("DownloadBinary returned error: %v", err)
+	}
+
+	content, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("failed to read installed binary: %v", err)
+	}
+	if string(content) != string(binaryContent) {
+		t.Fatalf("expected installed content %q, got %q", binaryContent, content)
+	}
+
+	if _, err := os.Stat(destPath + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("tmp file should not remain after successful install")
+	}
+}
+
 func TestDownloadBinaryChecksumMismatchPreservesOldBinary(t *testing.T) {
 	tmpDir := t.TempDir()
 	destPath := filepath.Join(tmpDir, "test-tool")
@@ -172,6 +211,30 @@ func TestDownloadBinaryChecksumMismatchPreservesOldBinary(t *testing.T) {
 
 	if _, statErr := os.Stat(destPath + ".tmp"); !os.IsNotExist(statErr) {
 		t.Fatalf("tmp file should be cleaned up after checksum mismatch")
+	}
+}
+
+func TestDownloadBinaryMissingChecksumEntryReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "test-tool")
+
+	withTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/test/repo/v1.2.3/test-tool-checksums.txt":
+			fmt.Fprint(w, "abc123  some-other-asset\n")
+		case "/releases/test/repo/v1.2.3/" + platformBinaryName("test-tool"):
+			w.Write([]byte("downloaded-binary"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	err := DownloadBinary("test/repo", "v1.2.3", "test-tool", destPath)
+	if err == nil {
+		t.Fatal("expected missing checksum entry error")
+	}
+	if !strings.Contains(err.Error(), "asset") {
+		t.Fatalf("expected missing checksum entry error, got %v", err)
 	}
 }
 
@@ -278,6 +341,21 @@ func TestRunToolList(t *testing.T) {
 				t.Errorf("first tool should be self (%s), got %s", tt.cfg.BinaryName, tools[0])
 			}
 		})
+	}
+}
+
+func TestIsHTTPStatus(t *testing.T) {
+	err := &httpStatusError{
+		statusCode: http.StatusNotFound,
+		status:     "404 Not Found",
+		url:        "https://example.com/file.txt",
+	}
+
+	if !isHTTPStatus(err, http.StatusNotFound) {
+		t.Fatal("expected 404 status to match")
+	}
+	if isHTTPStatus(err, http.StatusInternalServerError) {
+		t.Fatal("did not expect 500 status to match")
 	}
 }
 

--- a/whip/install.sh
+++ b/whip/install.sh
@@ -63,6 +63,40 @@ download_file() {
     error "Neither curl nor wget is installed"
 }
 
+download_optional_file() {
+    local url="$1" dest="$2"
+    local http_code output
+
+    if command -v curl &> /dev/null; then
+        if ! http_code=$(curl -sSL -w '%{http_code}' -o "$dest" "$url"); then
+            rm -f "$dest"
+            return 1
+        fi
+        case "$http_code" in
+            200) return 0 ;;
+            404)
+                rm -f "$dest"
+                return 2
+                ;;
+        esac
+        rm -f "$dest"
+        return 1
+    fi
+
+    if command -v wget &> /dev/null; then
+        if output=$(wget -q -S -O "$dest" "$url" 2>&1); then
+            return 0
+        fi
+        rm -f "$dest"
+        if printf '%s\n' "$output" | grep -Eq 'HTTP/[0-9.]+\s+404'; then
+            return 2
+        fi
+        return 1
+    fi
+
+    error "Neither curl nor wget is installed"
+}
+
 sha256_file() {
     local file="$1"
     if command -v sha256sum &> /dev/null; then
@@ -94,21 +128,28 @@ lookup_checksum() {
     ' "$manifest"
 }
 
-install_verified_binary() {
+install_binary_with_optional_checksum() {
     local download_url="$1" checksum_url="$2" asset_name="$3" dest="$4"
     local tmp="${dest}.tmp.$$" manifest="${tmp}.checksums"
-    local expected_checksum actual_checksum
+    local expected_checksum actual_checksum checksum_status
 
-    if ! download_file "$checksum_url" "$manifest"; then
-        rm -f "$tmp" "$manifest"
-        return 1
-    fi
-
-    expected_checksum=$(lookup_checksum "$manifest" "$asset_name")
-    if [ -z "$expected_checksum" ]; then
-        warn "Checksum entry not found for ${asset_name}"
-        rm -f "$tmp" "$manifest"
-        return 1
+    if download_optional_file "$checksum_url" "$manifest"; then
+        expected_checksum=$(lookup_checksum "$manifest" "$asset_name")
+        if [ -z "$expected_checksum" ]; then
+            warn "Checksum entry not found for ${asset_name}"
+            rm -f "$tmp" "$manifest"
+            return 1
+        fi
+    else
+        checksum_status=$?
+        if [ "$checksum_status" -eq 2 ]; then
+            warn "Checksum manifest not found for ${asset_name}; installing without checksum verification"
+            rm -f "$manifest"
+            expected_checksum=""
+        else
+            rm -f "$tmp" "$manifest"
+            return 1
+        fi
     fi
 
     if ! download_file "$download_url" "$tmp"; then
@@ -116,15 +157,17 @@ install_verified_binary() {
         return 1
     fi
 
-    if ! actual_checksum=$(sha256_file "$tmp"); then
-        rm -f "$tmp" "$manifest"
-        return 1
-    fi
+    if [ -n "$expected_checksum" ]; then
+        if ! actual_checksum=$(sha256_file "$tmp"); then
+            rm -f "$tmp" "$manifest"
+            return 1
+        fi
 
-    if [ "$actual_checksum" != "$expected_checksum" ]; then
-        warn "Checksum mismatch for ${asset_name}"
-        rm -f "$tmp" "$manifest"
-        return 1
+        if [ "$actual_checksum" != "$expected_checksum" ]; then
+            warn "Checksum mismatch for ${asset_name}"
+            rm -f "$tmp" "$manifest"
+            return 1
+        fi
     fi
 
     if ! chmod +x "$tmp"; then
@@ -187,7 +230,7 @@ install_binary() {
     local checksum_url="https://github.com/${REPO}/releases/download/${version}/${checksum_name}"
 
     step "Installing ${name} ${version}..."
-    if ! install_verified_binary "$download_url" "$checksum_url" "$download_name" "${INSTALL_DIR}/${binary_name}"; then
+    if ! install_binary_with_optional_checksum "$download_url" "$checksum_url" "$download_name" "${INSTALL_DIR}/${binary_name}"; then
         warn "Failed to download ${name}. It will be installed on first use via plugin hook."
         return 1
     fi


### PR DESCRIPTION
## Summary
- reject CR/LF-bearing release version input before writing to GITHUB_ENV in reusable release workflows
- restore install and upgrade compatibility for legacy releases that do not publish *-checksums.txt while still enforcing verification when manifests exist
- cover the shared upgrade fallback path with focused tests

## Validation
- go test ./... (in shared/upgrade)
- bash -n claude-irc/install.sh
- bash -n whip/install.sh
- fresh-install run of claude-irc/install.sh against v1.36.0 latest release
- fresh-install run of whip/install.sh against v1.36.0 latest release

## Context
PRs #9 and #11 were already merged, but stacked review uncovered two residual blockers: multiline version input could still inject into GITHUB_ENV, and the new checksum requirement broke fresh installs against the current latest release because v1.36.0 does not publish checksum manifest assets.
