### PR TITLE
feat(whip): tighten lead prompt guidance

### DIFF
--- a/whip/internal/whip/prompt_lead.go
+++ b/whip/internal/whip/prompt_lead.go
@@ -48,14 +48,20 @@ Run these commands to initialize your session:
 First, check for existing workers from a previous lead:
 `)
 	fmt.Fprintf(&b, "   whip task list --workspace %s\n", workspace)
-	b.WriteString(`If workers already exist (e.g., from a previous lead session), resume management — do NOT re-create them. Check their status, read their notes, and continue coordination from where the previous lead left off.
+	b.WriteString(`If workers already exist (e.g., from a previous lead session), resume management — do NOT re-create them. Check their status, read their notes, and continue coordination from where the previous lead left off. If the planned worker graph is already known from the task description or prior notes, create any missing planned workers promptly rather than waiting for upstream work to finish first.
 
 ## Creating Workers
 When you need to create worker tasks, use:
 `)
 	fmt.Fprintf(&b, "   whip task create \"<title>\" --workspace %s --backend <backend> --difficulty <level> --desc \"<description>\"\n", workspace)
 	b.WriteString(`   whip task dep <task-id> --after <prerequisite-id>  # encode stack order
-   whip task assign <task-id>  # only assign tasks without unmet prerequisites
+   whip task assign <task-id>  # only assign tasks that are unblocked
+
+Creation timing and assignment timing are different:
+- When the worker graph is already known, create the full planned worker set promptly.
+- Encode dependencies immediately with ` + "`whip task dep`" + ` so downstream tasks stay blocked until ready.
+- Do not wait for upstream work to finish before creating downstream tasks.
+- Only use ` + "`whip task assign`" + ` when a task is actually unblocked and ready to start.
 
 When writing worker descriptions, use this contract:
 - Context: why the task exists, how it fits the workspace objective, which patterns or constraints it must preserve, and why this direction was chosen
@@ -71,6 +77,8 @@ Do not rely on hidden lead-only context. The worker description must stand on it
 	fmt.Fprintf(&b, "- Use `whip workspace broadcast %s \"message\"` for workspace-wide announcements\n", workspace)
 	b.WriteString(`- Use ` + "`claude-irc msg <irc-name> \"message\"`" + ` for direct worker communication
 - Relay information between workers when they need context from each other
+- As prerequisites clear, assign newly unblocked workers promptly instead of re-planning or re-creating already-defined downstream work
+- Mirror major worker state changes, blockers, policy decisions, and review handoffs into the lead task note so ` + "`whip task view`" + ` stays current
 
 ### Review Flow
 For workers with ` + "`--review`" + `:
@@ -96,8 +104,10 @@ Escalate to Master via IRC when:
 - Share meaningful updates to Master via IRC — not just status changes
   Good: "2/4 workers done. Auth module landed. API client in review. Remaining: tests + CLI wiring."
   Bad: "Working on it."
+- Treat the lead task note as the durable mirror of workspace state, not a final summary. Update it whenever there is major progress, a blocker, a policy decision, or a review handoff.
+- If an IRC update changes the understood workspace state or plan, record the same point in the lead task note.
 `)
-	fmt.Fprintf(&b, "- Update progress notes: whip task note %s \"<progress>\"\n", task.ID)
+	fmt.Fprintf(&b, "- Update progress notes promptly: whip task note %s \"<progress>\"\n", task.ID)
 
 	b.WriteString(`
 ## Worker Failure Handling

--- a/whip/internal/whip/prompt_test.go
+++ b/whip/internal/whip/prompt_test.go
@@ -164,6 +164,39 @@ func TestCodexBackend_GenerateLeadPrompt(t *testing.T) {
 	}
 }
 
+func TestLeadPrompt_SeparatesCreationFromAssignmentAndMirrorsProgress(t *testing.T) {
+	task := NewTask("Lead Task", "Worker specs here", "/tmp")
+	task.Role = TaskRoleLead
+	task.Workspace = "my-ws"
+	task.IRCName = "wp-lead-my-ws"
+	task.MasterIRCName = "wp-master-my-ws"
+
+	cases := []struct {
+		name   string
+		prompt string
+	}{
+		{name: "claude", prompt: (&ClaudeBackend{}).GeneratePrompt(task)},
+		{name: "codex", prompt: (&CodexBackend{}).GeneratePrompt(task)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, want := range []string{
+				"create any missing planned workers promptly",
+				"create the full planned worker set promptly",
+				"Do not wait for upstream work to finish before creating downstream tasks.",
+				"Only use `whip task assign` when a task is actually unblocked and ready to start.",
+				"Mirror major worker state changes, blockers, policy decisions, and review handoffs into the lead task note",
+				"Treat the lead task note as the durable mirror of workspace state",
+			} {
+				if !strings.Contains(tc.prompt, want) {
+					t.Fatalf("lead prompt missing %q", want)
+				}
+			}
+		})
+	}
+}
+
 func TestWorkerPromptUnchangedWhenLeadExists(t *testing.T) {
 	worker := NewTask("Worker task", "Implement the feature", "/tmp")
 	worker.IRCName = "wp-abc12345"

--- a/whip/skills-codex/whip-plan/SKILL.md
+++ b/whip/skills-codex/whip-plan/SKILL.md
@@ -27,6 +27,9 @@ Your job is to:
 - Keep backend choice explicit when it affects quality, portability, or reproducibility.
 - Do not materialize a new workspace during planning. Planning decides `global` versus named `workspace`; execution creates or continues it later.
 - Present planning artifacts in the conversation and in the saved plan. Do not rely on client-only bindings or hidden planner context.
+- Keep phase boundaries explicit in the conversation. Present each phase artifact under its own phase heading, in order, so the user can review the plan step by step.
+- Do not collapse multiple phase artifacts into one combined summary when the user expects step-by-step reviewability. Be concise within a phase, not across phase boundaries.
+- Do not save the final plan file or run `$whip-start` until the user explicitly approves the Phase 5 plan presentation.
 - If the request is truly one self-contained task, keep the graph as a single `global` task instead of inventing extra parallel work. Still record why no split was needed.
 
 ## Phase 1 - Mental Model
@@ -54,6 +57,8 @@ Produce a brief artifact in the conversation before exploring. Use this minimal 
 - Working assumptions:
 - Candidate workspace model: global | workspace(<name>)
 ```
+
+Present this as its own Phase 1 artifact before moving to exploration. Do not merge it with later-phase artifacts in the same review checkpoint.
 
 When you pick a named workspace, remember that execution later resolves to one of two workspace models:
 - `git-worktree` if the first `whip task create --workspace <name>` runs inside git
@@ -99,6 +104,8 @@ Produce a brief exploration artifact in the conversation:
 - Risks, gaps, or hidden dependencies:
 ```
 
+Present this as its own Phase 2 artifact. Do not collapse it into the Mental Model or later planning phases.
+
 ### Phase complete only when
 
 - you can name the codebase or workflow areas that matter
@@ -132,6 +139,8 @@ When feedback is needed, produce a brief artifact in the conversation:
 - Recommendation:
 - User decision or recorded assumption:
 ```
+
+Keep feedback as its own phase artifact when it is needed so the user can react before you finalize the graph.
 
 ### Phase complete only when
 
@@ -228,6 +237,8 @@ Record the result in the conversation:
 - Final verdict:
 ```
 
+Present the simulation separately from the earlier exploration/feedback artifacts so the user can review the task graph validation on its own.
+
 ### Phase complete only when
 
 - ownership, dependencies, and round structure are explicit
@@ -286,6 +297,7 @@ Save the approved plan to:
 ### Present the plan to the user
 
 Present a concise but concrete plan summary before saving or executing.
+Keep the Phase 5 plan presentation separate from earlier phase artifacts and separate from any save/execute step. The user should be able to review the proposed plan on its own.
 
 ```text
 ## Plan: <project title>
@@ -330,7 +342,7 @@ Show the rendered output directly in the plan presentation. Each node `id` shoul
 - `~/.whip/plans/<plan-backend>-<descriptive-slug>.md`
 ```
 
-The user may approve, request changes, or ask questions. Do not save or execute until the user explicitly approves.
+The user may approve, request changes, or ask questions. Do not save or execute until the user explicitly approves. Do not pre-save a draft plan file and do not run `$whip-start` as part of the approval request.
 
 ### Phase complete only when
 
@@ -341,6 +353,7 @@ The user may approve, request changes, or ask questions. Do not save or execute 
 ## Phase 6 - Execution
 
 After approval, save the plan as a self-contained document and hand it off to `$whip-start`.
+Approval must already be explicit in the conversation. If the user asks follow-up questions or requests changes, stay in planning mode, present the revised phase artifact(s) separately, and ask again instead of saving early.
 
 ### Write the plan file
 

--- a/whip/skills-codex/whip-start/SKILL.md
+++ b/whip/skills-codex/whip-start/SKILL.md
@@ -282,6 +282,7 @@ whip task assign <lead-id> --master-irc <resolved-master-irc>
 - Run `claude-irc inbox` after each meaningful action or when you expect a lead escalation.
 - Once the lead is terminal or you are about to quit, stop polling.
 - Use `whip task list` to monitor overall workspace state.
+- Use `whip task view <lead-id>` and the lead task notes as the durable status mirror; the lead is expected to mirror major progress, blockers, policy decisions, and review handoffs there, not only in IRC.
 - Review lead updates and answer questions promptly.
 
 ### Step 4: Handle escalations from the lead


### PR DESCRIPTION
## Summary
- clarify the lead prompt so worker creation happens promptly while assignment still respects dependency blocking
- require lead task notes to mirror major state changes, blockers, policy decisions, and review handoffs
- tighten codex whip planning guidance so phase artifacts stay step-by-step and approval happens before save/execute

## Verification
- `cd whip && go test ./...`
