### PR TITLE
feat(whip): install codex skills on install and upgrade

### DIFF
--- a/.github/scripts/sync-codex-skills-manifest.sh
+++ b/.github/scripts/sync-codex-skills-manifest.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Generates whip/skills-codex/manifest.txt from the directory contents.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/whip/skills-codex"
+OUTPUT="$SKILLS_DIR/manifest.txt"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+    echo "Error: $SKILLS_DIR not found" >&2
+    exit 1
+fi
+
+files=$(cd "$SKILLS_DIR" && find . -type f ! -name manifest.txt | sed 's|^\./||' | sort)
+
+if [ -z "$files" ]; then
+    echo "Error: no skill files found in $SKILLS_DIR" >&2
+    exit 1
+fi
+
+printf '%s\n' "$files" > "$OUTPUT"
+echo "Generated $OUTPUT with $(echo "$files" | wc -l | tr -d ' ') file(s)"

--- a/.github/workflows/cc-marketplace-release.yml
+++ b/.github/workflows/cc-marketplace-release.yml
@@ -49,11 +49,14 @@ jobs:
           # Generate marketplace.json
           bash .github/scripts/sync-marketplace.sh "$VERSION"
 
+          # Generate codex skills manifest
+          bash .github/scripts/sync-codex-skills-manifest.sh
+
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add '*/.claude-plugin/plugin.json' .claude-plugin/marketplace.json
+          git add '*/.claude-plugin/plugin.json' .claude-plugin/marketplace.json whip/skills-codex/manifest.txt
           if git diff --cached --quiet; then
             echo "No changes"
           else

--- a/shared/upgrade/upgrade.go
+++ b/shared/upgrade/upgrade.go
@@ -24,6 +24,7 @@ type Config struct {
 	Version               string                                       // Current version (set via -ldflags)
 	CompanionTools        []string                                     // Additional tools to upgrade alongside self
 	ResolveCompanionTools func(repo, version string) ([]string, error) // Optional callback to resolve companions for the target version
+	PostUpgrade           func(repo, version string) error             // Optional callback to run after successful upgrade
 }
 
 var (
@@ -298,6 +299,11 @@ func Run(cfg Config) error {
 
 	if cfg.Version != "dev" && latestVersion == cfg.Version {
 		fmt.Fprintf(os.Stderr, "Already up to date (%s)\n", cfg.Version)
+		if cfg.PostUpgrade != nil {
+			if err := cfg.PostUpgrade(cfg.Repo, latestVersion); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: post-upgrade: %v\n", err)
+			}
+		}
 		return nil
 	}
 
@@ -345,5 +351,12 @@ func Run(cfg Config) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Updated to %s\n", latestVersion)
+
+	if cfg.PostUpgrade != nil {
+		if err := cfg.PostUpgrade(cfg.Repo, latestVersion); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: post-upgrade: %v\n", err)
+		}
+	}
+
 	return nil
 }

--- a/whip/cmd/whip/cmd_misc.go
+++ b/whip/cmd/whip/cmd_misc.go
@@ -18,6 +18,7 @@ func upgradeCmd() *cobra.Command {
 				BinaryName:            "whip",
 				Version:               version,
 				ResolveCompanionTools: fetchWhipCompanionTools,
+				PostUpgrade:           installCodexSkills,
 			})
 		},
 	}

--- a/whip/cmd/whip/codex_skills.go
+++ b/whip/cmd/whip/codex_skills.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var (
+	codexSkillsHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+	codexSkillsRawURL = func(repo, version, path string) string {
+		return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/whip/skills-codex/%s", repo, version, path)
+	}
+)
+
+func codexHome() string {
+	if h := os.Getenv("CODEX_HOME"); h != "" {
+		return h
+	}
+	return filepath.Join(os.Getenv("HOME"), ".codex")
+}
+
+func fetchCodexSkillManifest(repo, version string) ([]string, error) {
+	url := codexSkillsRawURL(repo, version, "manifest.txt")
+	resp, err := codexSkillsHTTPClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch codex skills manifest: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %s for %s", resp.Status, url)
+	}
+
+	var files []string
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Contains(line, "..") || filepath.IsAbs(line) {
+			continue
+		}
+		files = append(files, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read codex skills manifest: %w", err)
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("codex skills manifest is empty")
+	}
+
+	return files, nil
+}
+
+func installCodexSkills(repo, version string) error {
+	home := codexHome()
+	if _, err := os.Stat(home); os.IsNotExist(err) {
+		return nil
+	}
+
+	skillFiles, err := fetchCodexSkillManifest(repo, version)
+	if err != nil {
+		return err
+	}
+
+	skillsDir := filepath.Join(home, "skills")
+	var lastErr error
+
+	for _, skill := range skillFiles {
+		dest := filepath.Join(skillsDir, skill)
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			lastErr = err
+			continue
+		}
+
+		url := codexSkillsRawURL(repo, version, skill)
+		if err := downloadCodexSkill(url, dest); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to download %s: %v\n", skill, err)
+			lastErr = err
+			continue
+		}
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("some codex skills failed to install: %w", lastErr)
+	}
+
+	fmt.Fprintf(os.Stderr, "Codex skills installed to %s\n", skillsDir)
+	return nil
+}
+
+func downloadCodexSkill(url, dest string) error {
+	resp, err := codexSkillsHTTPClient.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %s for %s", resp.Status, url)
+	}
+
+	tmp := dest + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	os.Remove(dest)
+	return os.Rename(tmp, dest)
+}

--- a/whip/install.sh
+++ b/whip/install.sh
@@ -335,6 +335,61 @@ install_binary() {
     return 0
 }
 
+install_codex_skills() {
+    local version="$1"
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+
+    if [ ! -d "$codex_home" ]; then
+        return 0
+    fi
+
+    local skills_dest="$codex_home/skills"
+    local raw_base="https://raw.githubusercontent.com/${REPO}/${version}/whip/skills-codex"
+    local manifest_url="$raw_base/manifest.txt"
+    local manifest failed=0 installed=0
+
+    if ! manifest=$(download_text "$manifest_url" 2>/dev/null); then
+        warn "Failed to fetch Codex skills manifest"
+        return 0
+    fi
+
+    if [ -z "$(printf '%s' "$manifest" | tr -d '[:space:]')" ]; then
+        warn "Codex skills manifest is empty"
+        return 0
+    fi
+
+    step "Installing Codex skills..."
+    local skill
+    while IFS= read -r skill || [ -n "$skill" ]; do
+        skill="$(trim_whitespace "$skill")"
+        [ -z "$skill" ] && continue
+        case "$skill" in \#*) continue ;; esac
+        case "$skill" in *..* | /*) continue ;; esac
+        local dest="$skills_dest/$skill"
+        local tmp="${dest}.tmp"
+        if ! mkdir -p "$(dirname "$dest")" 2>/dev/null; then
+            warn "  Failed to create directory for $skill"
+            failed=$((failed + 1))
+            continue
+        fi
+        if download_file "$raw_base/$skill" "$tmp" && mv -f "$tmp" "$dest"; then
+            installed=$((installed + 1))
+        else
+            rm -f "$tmp"
+            warn "  Failed to download $skill"
+            failed=$((failed + 1))
+        fi
+    done <<< "$manifest"
+
+    if [ "$installed" -eq 0 ] && [ "$failed" -eq 0 ]; then
+        warn "  Codex skills manifest has no valid entries"
+    elif [ "$failed" -eq 0 ]; then
+        info "  Codex skills installed to $skills_dest"
+    else
+        warn "  Codex skills partially installed ($failed failed)"
+    fi
+}
+
 main() {
     echo ""
     echo -e "${CYAN}Setting up whip — Task Orchestrator for Claude Code${NC}"
@@ -370,6 +425,8 @@ main() {
     done
 
     ensure_path
+
+    install_codex_skills "$version"
 
     echo ""
     info "whip ${version} installed successfully!"

--- a/whip/skills-codex/manifest.txt
+++ b/whip/skills-codex/manifest.txt
@@ -1,0 +1,4 @@
+whip-lesson-learn/SKILL.md
+whip-lesson-learn/agents/openai.yaml
+whip-plan/SKILL.md
+whip-start/SKILL.md


### PR DESCRIPTION
## Summary
- When `~/.codex` exists, `whip install.sh` and `whip upgrade` now download skills from `whip/skills-codex/manifest.txt` to `~/.codex/skills/`
- Added `PostUpgrade` callback to `shared/upgrade.Config` — runs after upgrade and on already-up-to-date path
- Manifest is auto-generated by CI on release via `.github/scripts/sync-codex-skills-manifest.sh`

## Changed files
| File | Change |
|---|---|
| `shared/upgrade/upgrade.go` | `PostUpgrade` callback field + invocation |
| `whip/cmd/whip/codex_skills.go` | New: manifest fetch + staged skill download |
| `whip/cmd/whip/cmd_misc.go` | Wire `PostUpgrade: installCodexSkills` |
| `whip/install.sh` | `install_codex_skills()` with manifest-based install |
| `whip/skills-codex/manifest.txt` | Auto-generated skill file list |
| `.github/scripts/sync-codex-skills-manifest.sh` | New: manifest generation script |
| `.github/workflows/cc-marketplace-release.yml` | Add manifest gen + git add |

## Safety measures
- Staged writes (tmp + mv) in both Go and bash
- Path traversal guard (skip `..` and absolute paths)
- Non-fatal: skill install failure doesn't break binary install/upgrade
- Empty manifest detection
- Windows-safe `os.Remove` before `os.Rename`
- `~/.codex` must already exist — we don't create it

## Test plan
- [x] `go build ./cmd/whip/` passes
- [x] `go vet ./cmd/whip/` passes
- [x] `go test ./...` passes (shared/upgrade + whip)
- [x] `bash -n whip/install.sh` passes
- [x] Manifest sync script generates correct output
- [ ] Manual: run `whip upgrade` with `~/.codex` present → skills appear
- [ ] Manual: run `whip upgrade` without `~/.codex` → no error, skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)