### PR TITLE
chore: unify Go version to 1.26 across all modules

### DIFF
--- a/claude-irc/go.mod
+++ b/claude-irc/go.mod
@@ -1,6 +1,6 @@
 module github.com/bang9/ai-tools/claude-irc
 
-go 1.21
+go 1.26
 
 require (
 	github.com/bang9/ai-tools/shared/irclib v0.0.0

--- a/redit/go.mod
+++ b/redit/go.mod
@@ -1,6 +1,6 @@
 module github.com/bang9/ai-tools/redit
 
-go 1.25.7
+go 1.26
 
 require github.com/bang9/ai-tools/shared/upgrade v0.0.0
 

--- a/rewind/go.mod
+++ b/rewind/go.mod
@@ -1,6 +1,6 @@
 module github.com/bang9/ai-tools/rewind
 
-go 1.24.0
+go 1.26
 
 require (
 	github.com/bang9/ai-tools/shared/upgrade v0.0.0

--- a/shared/irclib/go.mod
+++ b/shared/irclib/go.mod
@@ -1,3 +1,3 @@
 module github.com/bang9/ai-tools/shared/irclib
 
-go 1.21
+go 1.26

--- a/shared/upgrade/go.mod
+++ b/shared/upgrade/go.mod
@@ -1,3 +1,3 @@
 module github.com/bang9/ai-tools/shared/upgrade
 
-go 1.21
+go 1.26

--- a/vaultkey/go.mod
+++ b/vaultkey/go.mod
@@ -1,6 +1,6 @@
 module github.com/bang9/ai-tools/vaultkey
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/bang9/ai-tools/shared/upgrade v0.0.0

--- a/webform/go.mod
+++ b/webform/go.mod
@@ -1,6 +1,6 @@
 module github.com/bang9/ai-tools/webform
 
-go 1.22
+go 1.26
 
 require github.com/bang9/ai-tools/shared/upgrade v0.0.0
 

--- a/whip/go.mod
+++ b/whip/go.mod
@@ -1,6 +1,6 @@
 module github.com/bang9/ai-tools/whip
 
-go 1.24.0
+go 1.26
 
 require (
 	github.com/bang9/ai-tools/shared/irclib v0.0.0


### PR DESCRIPTION
## Summary
- Go 1.25 binaries trigger CrowdStrike Falcon static file scan false positives (quarantined on write, before execution)
- Go 1.21 and 1.26 binaries pass CrowdStrike cleanly
- Unify all 8 go.mod files to `go 1.26`
- CI uses `go-version-file` referencing go.mod, so build toolchain updates automatically

## Test plan
- [x] Local build with Go 1.26 + `cp` to `~/.local/bin/` — CrowdStrike did not quarantine
- [x] Verified Go 1.25.7 build gets quarantined, Go 1.26.0 build survives
- [ ] CI builds pass with Go 1.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)