### PR TITLE
fix(grove): respect configured base branch during source repo sync

### DIFF
--- a/grove/grove-core/src/git_project.rs
+++ b/grove/grove-core/src/git_project.rs
@@ -1352,7 +1352,7 @@ pub fn refresh_project_impl(project_id: &str) -> Result<Project, String> {
         return Err(format!("Source directory not found: {}", entry.source_path));
     }
 
-    refresh_source_repo(source)?;
+    refresh_source_repo(source, entry.base_branch.as_deref())?;
     Ok(project_from_entry(entry))
 }
 
@@ -1591,8 +1591,22 @@ fn restore_source_sync_stash(source: &Path, stash_ref: &str, context: &str) -> R
     Ok(())
 }
 
-fn refresh_source_repo(source: &Path) -> Result<(), String> {
-    let default_branch = remote_default_branch(source)?;
+fn refresh_source_repo(source: &Path, base_branch: Option<&str>) -> Result<(), String> {
+    let default_branch = match base_branch {
+        Some(branch) => {
+            let remote_ref = format!("refs/remotes/origin/{branch}");
+            if run_git(source, &["show-ref", "--verify", &remote_ref]).is_ok() {
+                branch.to_string()
+            } else {
+                eprintln!(
+                    "Configured base branch '{}' not found on remote, falling back to auto-detect",
+                    branch
+                );
+                remote_default_branch(source)?
+            }
+        }
+        None => remote_default_branch(source)?,
+    };
     let sync_stash_ref = create_source_sync_stash(source)?;
 
     let restore_after_error = |base: String| -> Result<(), String> {
@@ -2714,6 +2728,84 @@ mod tests {
             run_git_output(&source_dir, &["branch", "--show-current"]).unwrap(),
             "trunk"
         );
+    }
+
+    #[test]
+    fn refresh_project_uses_configured_base_branch_instead_of_remote_default() {
+        let _lock = env_lock();
+        let home = TestHome::new();
+        let base_dir = home.root.join("grove-data");
+        let source_dir = base_dir
+            .join("github.com")
+            .join("bang9")
+            .join("grove")
+            .join("source");
+        let remotes_dir = home.root.join("remotes");
+        let (remote_dir, seed_dir) =
+            create_bare_remote(&remotes_dir, "grove-base-branch", "trunk");
+
+        commit_and_push(
+            &seed_dir,
+            &remote_dir,
+            "trunk",
+            "README.md",
+            "# Grove v1\n",
+            "Initial commit",
+        );
+
+        // Create a "develop" branch on the remote
+        run_git_ok(&seed_dir, &["checkout", "-b", "develop"]);
+        commit_and_push(
+            &seed_dir,
+            &remote_dir,
+            "develop",
+            "dev.md",
+            "# Dev\n",
+            "Dev commit",
+        );
+
+        fs::create_dir_all(source_dir.parent().unwrap()).unwrap();
+        let remote_dir_str = remote_dir.to_string_lossy().to_string();
+        let source_dir_str = source_dir.to_string_lossy().to_string();
+        run_git_ok(
+            source_dir.parent().unwrap(),
+            &["clone", &remote_dir_str, &source_dir_str],
+        );
+
+        // Save config with base_branch set to "develop"
+        let mut entry = project_entry(
+            "project-base",
+            "https://github.com/bang9/grove.git",
+            &source_dir,
+        );
+        entry.base_branch = Some("develop".to_string());
+        save_test_config(&base_dir, vec![entry]);
+
+        // Push a new commit to develop on the remote
+        run_git_ok(&seed_dir, &["checkout", "develop"]);
+        commit_and_push(
+            &seed_dir,
+            &remote_dir,
+            "develop",
+            "dev.md",
+            "# Dev v2\n",
+            "Update dev",
+        );
+
+        let project = refresh_project_impl("project-base").unwrap();
+
+        // Should be on "develop", NOT "trunk"
+        assert_eq!(
+            run_git_output(&source_dir, &["branch", "--show-current"]).unwrap(),
+            "develop"
+        );
+        // Remote changes on develop should be pulled
+        assert_eq!(
+            fs::read_to_string(source_dir.join("dev.md")).unwrap(),
+            "# Dev v2\n"
+        );
+        // base_branch should be preserved in the returned project
+        assert_eq!(project.base_branch, Some("develop".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `refresh_source_repo()`가 항상 `remote_default_branch()`만 호출하여 사용자가 설정한 `base_branch`를 무시하던 버그 수정
- `base_branch: Option<&str>` 파라미터를 추가하고, 설정된 경우 해당 브랜치를 사용 (리모트에 없으면 auto-detect fallback)
- `add_worktree`(line ~1036)에서 이미 사용 중인 동일한 show-ref/verify 패턴 적용

## Test plan
- [x] 새 테스트 `refresh_project_uses_configured_base_branch_instead_of_remote_default` 추가 (TDD red→green)
- [x] 기존 refresh_project 테스트 6개 모두 통과 확인
- [x] whip 코드리뷰 에이전트 LGTM